### PR TITLE
Work invite utan family

### DIFF
--- a/assistant.py
+++ b/assistant.py
@@ -1,6 +1,6 @@
 import json
 import os
-import random 
+import random
 import urllib
 
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
@@ -90,7 +90,17 @@ def get_top_intent(response_output: dict):
 #  'comment': string,
 #  'UMember': string
 #  }]
-def utan_message_Switcher(watson_message):
+def utan_message_Switcher(watson_message: dict):
+    if len(watson_message["intents"]) <= 0:
+        # 解析された意図がない場合、デフォルトメッセージを台本として出力
+        return [
+            {
+                "intent": None,
+                "comment": watson_message["generic"][0]["text"],
+                "UMember": "うーたん",
+            }
+        ]
+
     intents = watson_message["intents"][0]
     message = watson_message["generic"][0]
     utan_message = []

--- a/assistant.py
+++ b/assistant.py
@@ -1,5 +1,7 @@
 import json
 import os
+import random 
+import urllib
 
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 from ibm_watson import AssistantV2

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,11 @@
 
 [Heroku: u-tan-bot](https://dashboard.heroku.com/apps/u-tan-bot)<br>
 言語：Python
+#### Heroku App スリープ解除Bot
+
+Herokuのフリープランでホストする場合、30分毎にAppがスリープ状態になる。<br>
+うーたんBotの動作の妨げになるため、
+[@tetsuji1122](https://github.com/tetsuji1122)氏の個人アカウントから、[UptimeRobot](http://uptimerobot.com/)を設定している。
 
 ### ユーザー環境
 

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@
     pip3 install -r requirements.txt
     ```
 
-### 4. 読みやすいコードのために
+### 3-2. 読みやすいコードのために
 
 #### Python Linter/Formatter
 
@@ -63,7 +63,7 @@ pysen run format
 
 設定内容は、[pyproject.toml](./pyproject.toml)で確認できます。
 
-### 5. デプロイ
+### 3-3. デプロイ
 
 当リポジトリのmainブランチを、herokuのAutoDeployに設定しています。<br>
 mainブランチへのcommitは、本番環境に即時展開されます。<br>

--- a/utan.py
+++ b/utan.py
@@ -4,6 +4,9 @@ import assistant
 from flask import Flask, request
 from slack_bolt import App
 from slack_bolt.adapter.flask import SlackRequestHandler
+from webhook_posting import WebhookPosting
+
+posting_proc = WebhookPosting()
 
 try:
     from dotenv import load_dotenv
@@ -32,16 +35,11 @@ def read_mention_message(event, say):
     # Watson APIに渡して、解析
     res_output = assistant.message_less(text)
 
-    # 確信度が一番高い、意図を取得
-    intent, error = assistant.get_top_intent(res_output)
+    # WatsonAPI出力から、台本生成
+    script = assistant.utan_message_Switcher(res_output)
 
-    # 意図が取得できない場合、エラーを通知
-    if intent is None:
-        say(r"解析エラーやで、あかんわ。:" + error)
-        return
-
-    # 意図を返事する
-    say(r"{0}".format(intent))
+    # 台本に従い、Webhookにpost
+    posting_proc(script)
 
 
 app = Flask(__name__)

--- a/webhook_posting.py
+++ b/webhook_posting.py
@@ -1,9 +1,10 @@
-from enum import Enum
 import json
 import os
-import requests
-import time
 import random
+import time
+from enum import Enum
+
+import requests
 
 try:
     from dotenv import load_dotenv
@@ -11,6 +12,7 @@ try:
     load_dotenv()
 except ImportError:
     print(__file__ + r":環境変数の読込にdotenvを使用せず続行します。")
+
 
 class WebhookPosting:
     class ScriptKeys(Enum):
@@ -28,13 +30,13 @@ class WebhookPosting:
     __URUN_WEBHOOK = os.getenv(r"URUN_INCOMING_WEBHOOK")
     __UTARO_WEBHOOK = os.getenv(r"UTARO_INCOMING_WEBHOOK")
 
-    def __get_umember_type(self, member_name: str)->UMember:
+    def __get_umember_type(self, member_name: str) -> UMember:
         assert isinstance(member_name, str)
 
         if self.UMember.Utan.value == member_name:
             return self.UMember.Utan
         elif self.UMember.Utako.value == member_name:
-            return self.UMember.Utako 
+            return self.UMember.Utako
         elif self.UMember.Urun.value == member_name:
             return self.UMember.Urun
         elif self.UMember.Utako.value == member_name:
@@ -55,7 +57,7 @@ class WebhookPosting:
             AssertionError(r"Undefined UMember Type" + member)
 
     def __call__(self, script: list):
-        assert isinstance(script , list)
+        assert isinstance(script, list)
 
         for item in script:
             assert isinstance(item, dict)
@@ -65,16 +67,9 @@ class WebhookPosting:
 
             webhook = self.__get_webhook_url(self.__get_umember_type(umember))
 
-            self.__post_incoming_webhook(url = webhook, comment = comment)
+            self.__post_incoming_webhook(url=webhook, comment=comment)
 
             time.sleep(1 + random.randint(0, 5) * 0.1)
-        
-    def __post_incoming_webhook(self, url: str, comment:str):
-        requests.post(
-            url = url,
-            data = json.dumps(
-                {
-                    r"text": comment
-                }
-            )
-        )
+
+    def __post_incoming_webhook(self, url: str, comment: str):
+        requests.post(url=url, data=json.dumps({r"text": comment}))

--- a/webhook_posting.py
+++ b/webhook_posting.py
@@ -1,0 +1,80 @@
+from enum import Enum
+import json
+import os
+import requests
+import time
+import random
+
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+except ImportError:
+    print(__file__ + r":環境変数の読込にdotenvを使用せず続行します。")
+
+class WebhookPosting:
+    class ScriptKeys(Enum):
+        Comment = r"comment"
+        UMember = r"UMember"
+
+    class UMember(Enum):
+        Utan = r"うーたん"
+        Utako = r"うたこ"
+        Urun = r"うーるん"
+        Utaro = r"うーたろ"
+
+    __UTAN_WEBHOOK = os.getenv(r"UTAN_INCOMING_WEBHOOK")
+    __UTAKO_WEBHOOK = os.getenv(r"UTAKO_INCOMING_WEBHOOK")
+    __URUN_WEBHOOK = os.getenv(r"URUN_INCOMING_WEBHOOK")
+    __UTARO_WEBHOOK = os.getenv(r"UTARO_INCOMING_WEBHOOK")
+
+    def __get_umember_type(self, member_name: str)->UMember:
+        assert isinstance(member_name, str)
+
+        if self.UMember.Utan.value == member_name:
+            return self.UMember.Utan
+        elif self.UMember.Utako.value == member_name:
+            return self.UMember.Utako 
+        elif self.UMember.Urun.value == member_name:
+            return self.UMember.Urun
+        elif self.UMember.Utako.value == member_name:
+            return self.UMember.Utaro
+        else:
+            AssertionError(r"Unknown UMember Name: " + member_name)
+
+    def __get_webhook_url(self, member: UMember):
+        if member == self.UMember.Utan:
+            return self.__UTAN_WEBHOOK
+        elif member == self.UMember.Utako:
+            return self.__UTAKO_WEBHOOK
+        elif member == self.UMember.Urun:
+            return self.__URUN_WEBHOOK
+        elif member == self.UMember.Utaro:
+            return self.__UTARO_WEBHOOK
+        else:
+            AssertionError(r"Undefined UMember Type" + member)
+
+    def __call__(self, script: list):
+        assert isinstance(script , list)
+
+        for item in script:
+            assert isinstance(item, dict)
+
+            umember = item[self.ScriptKeys.UMember.value]
+            comment = item[self.ScriptKeys.Comment.value]
+
+            webhook = self.__get_webhook_url(self.__get_umember_type(umember))
+
+            self.__post_incoming_webhook(url = webhook, comment = comment)
+
+            time.sleep(1 + random.randint(0, 5) * 0.1)
+        
+    def __post_incoming_webhook(self, url: str, comment:str):
+        requests.post(
+            url = url,
+            data = json.dumps(
+                {
+                    r"text": comment
+                }
+            )
+        )


### PR DESCRIPTION
# 作業内容

## 1. うーたん家族のIncoming Webhookへの投稿処理

assistant.utan_message_Switcherの出力を台本として引数に受け取り、
うーたん家族のIncoming WebhookへPOSTリクエストを行うクラス([webhook_posing.py](./webhook_posing.py))の追加

## 2. assistant.utan_message_Switcherの冒頭に処理追加

```watson_message["intents"]```が要素を持たない場合、```watson_message["generic"][0]["text"]```のメッセージを出力するよう追加

## 3. ReadMe.md修正

章立て番号変更
UptimeRobotに関する記述を追加
